### PR TITLE
Double check for available appointments

### DIFF
--- a/vaccine-appts.py
+++ b/vaccine-appts.py
@@ -31,7 +31,7 @@ def load_data(state):
 
 @task
 def available_appts(df, current_coords, distance_miles=None, filters=None):
-    close_df = df[df.appointments_available == True]
+    close_df = df[(df.appointments_available == True) & df.appointments]
     close_df['distance_miles'] = close_df['coordinates'].apply(
         lambda x: haversine.haversine(x, current_coords, unit=Unit.MILES)
     )


### PR DESCRIPTION
Why?
- CVS stores with "Limited Availability" can say that they have
    available appointments, but then turn out to have an empty
    appointment list. This causes the whole program to crash.

How?
- Only say that appointments are found if the search returns
    a non-empty list of appointments.

Side effects?
- Unclear whether there's any real significance to
    "Limited Availability"